### PR TITLE
chore: Rename to argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ members = [
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
 bellpepper-core = { version = "0.4.0", default-features = false }
-bellpepper = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
+bellpepper = { git = "https://github.com/argumentcomputer/bellpepper", branch = "dev", default-features = false }
 blake2s_simd = "1.0.1"
 blstrs = { version = "0.7.0" }
 ff = "0.13.0"


### PR DESCRIPTION
Fixes downstream `cargo-deny` errors